### PR TITLE
Add basic support for installing on Ubuntu machines

### DIFF
--- a/install
+++ b/install
@@ -10,15 +10,15 @@ main() {
         return 1
     fi
 
+    install_packages
+    setup_shell
+
     cd "$BASEDIR"
     echo "Downloading all git submodules"
     git submodule update --init --recursive
 
     run_gitconfig_setup
     run_dotbot
-
-    install_packages
-    setup_shell
 }
 
 # Run the gitconfig setup script. This should be run prior to linking the gitconfig, as it creates

--- a/install
+++ b/install
@@ -5,19 +5,17 @@ set -euo pipefail
 BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 main() {
-    cd "$BASEDIR"
+    if ! on_macos && ! on_linux; then
+        echo "Unsupported operating system"
+        return 1
+    fi
 
+    cd "$BASEDIR"
     echo "Downloading all git submodules"
     git submodule update --init --recursive
 
     run_gitconfig_setup
     run_dotbot
-
-    # Past this point is all macOS specific.
-    # TODO: Add support for linux (specifically ubuntu?)
-    if ! on_macos; then
-        echo "The rest of the install script is currently macOS-specific. Ending here for now..."
-    fi
 
     install_packages
     setup_shell
@@ -42,38 +40,121 @@ run_dotbot() {
 # Install packages and apps. These may be packages that are requirements for other programs (e.g.
 # some neovim plugins require ripgrep), or they may be things that I commonly use.
 install_packages() {
+    if on_macos; then
+        install_macos_packages
+    elif on_linux; then
+        install_linux_packages
+    fi
+}
+
+install_macos_packages() {
     # TODO: Automatically install homebrew if on macOS
     if ! cmd_exists "brew"; then
         echo "Homebrew is not installed"
         exit 1
     fi
 
-    brew tap homebrew/cask
-    brew tap homebrew/cask-fonts
-    # Needed for font-sf-mono-nerd-font
-    brew tap epk/epk
+    local mac_packages="$BASEDIR/packages/macos"
+    local taps="$mac_packages/taps.txt"
+    local formulae="$mac_packages/formulae.txt"
+    local casks="$mac_packages/casks.txt"
 
-    local formulae=(
-        "curl" "bat" "exa" "fish" "gh" "git" "git-delta" "go" "less" "neovim" "node" "python3"
-        "ripgrep" "virtualenv" "wget"
-    )
-
-    local casks=(
-        "docker" "iterm2" "font-jetbrains-mono" "font-sf-mono-nerd-font" "raycast" "spotify"
-        "visual-studio-code"
-    )
+    echo "Tapping repositories"
+    while IFS="" read -r tap || [ -n "$tap" ]; do
+        if should_ignore_line "$tap"; then continue; fi
+        brew tap "$tap"
+    done < "$taps"
 
     echo "Installing any missing formulae"
-    for formula in "${formulae[@]}"; do
+    while IFS="" read -r formula || [ -n "$formula" ]; do
+        if should_ignore_line "$formula"; then continue; fi
         brew list "$formula" &> /dev/null || brew install "$formula"
-    done
-
-
+    done < "$formulae"
 
     echo "Installing any missing casks"
-    for cask in "${casks[@]}"; do
+    while IFS="" read -r cask || [ -n "$cask" ]; do
+        if should_ignore_line "$cask"; then continue; fi
         brew list --cask "$cask" &> /dev/null || brew install --cask "$cask"
-    done
+    done < "$casks"
+}
+
+install_linux_packages() {
+    local apt_packages="$BASEDIR/packages/linux/apt.txt"
+
+    echo "Upgrading current packages"
+    sudo apt update && sudo apt upgrade -y
+
+    echo "Installing apt packages"
+    while IFS="" read -r pkg || [ -n "$pkg" ]; do
+        if should_ignore_line "$pkg"; then continue; fi
+        sudo apt install "$pkg" -y
+    done < "$apt_packages"
+
+    # FIXME These will currently reinstall the same version if it is already installed.
+    install_gh_cli
+    install_git_delta
+    install_go
+    install_neovim
+    install_nodejs
+}
+
+# Installs the GitHub CLI using apt
+# https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
+install_gh_cli() {
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    sudo apt update
+    sudo apt install gh
+}
+
+# Installs git-delta using the .deb release file
+# https://dandavison.github.io/delta/installation.html
+install_git_delta() {
+    local arch="$(dpkg --print-architecture)"
+    local repository="dandavison/delta"
+    local version=$(get_latest_release "$repository")
+    local release_file="git-delta_${version}_${arch}.deb"
+
+    local tempdir="$(mktemp -d)"
+    wget -P "$tempdir" "https://github.com/$repository/releases/download/$version/$release_file"
+    sudo apt install "$tempdir/$release_file"
+
+    rm -rf "$tempdir"
+}
+
+# Installs the latest version of Go using the pre-built binaries
+# https://go.dev/doc/install
+# https://github.com/golang/go/issues/51135#issuecomment-1036043491
+install_go() {
+    local arch="$(dpkg --print-architecture)"
+    local release_file=$(curl "https://go.dev/dl/?mode=json" | jq -r '.[0].files[].filename | select(test("go.*.linux-'"$arch"'.tar.gz"))')
+    local tempdir="$(mktemp -d)"
+    wget -P "$tempdir" "https://go.dev/dl/$release_file"
+
+    # Remove old installation and then install the new version
+    sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf "$tempdir/$release_file"
+    rm -rf "$tempdir"
+}
+
+# Installs the latest release of neovim
+# https://github.com/neovim/neovim/wiki/Installing-Neovim#install-from-download
+install_neovim() {
+    local repository="neovim/neovim"
+    local version=$(get_latest_release "$repository")
+    local release_file="nvim-linux64.deb"
+
+    local tempdir="$(mktemp -d)"
+    wget -P "$tempdir" "https://github.com/$repository/releases/download/$version/$release_file"
+    sudo apt install "$tempdir/$release_file"
+
+    rm -rf "$tempdir"
+}
+
+# Installs node.js using the pre-built distributions
+# https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
+install_nodejs() {
+    curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash -
+    sudo apt-get install -y nodejs
 }
 
 # Make sure the proper shell is the default and all dependencies are installed.
@@ -127,9 +208,29 @@ on_macos() {
     [ "$(uname -s)" == "Darwin" ]
 }
 
+# Returns 0 if the script is running on Linux.
+on_linux() {
+    [ "$(uname -s)" == "Linux" ]
+}
+
 # Returns 0 if the given pattern ($1) exists in the file ($2).
 pattern_exists() {
     grep -q "$1" "$2"
+}
+
+# Returns 0 if the given line ($1) should be ignored/skipped when looping through a package file.
+# This skips blank lines and lines starting with '#' (used as comments).
+should_ignore_line() {
+    # https://stackoverflow.com/a/2172367
+    [ "$1" == "" ] || [[ "$1" == \#* ]]
+}
+
+# Returns the version of the latest release for a github repo.
+# https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c
+get_latest_release() {
+    curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from API
+        grep '"tag_name":' |                                          # Get tag line
+        sed -E 's/.*"([^"]+)".*/\1/'                                  # Pluck JSON value
 }
 
 main "$@"

--- a/install
+++ b/install
@@ -174,7 +174,7 @@ setup_shell() {
 
     if ! cmd_exists "starship"; then
         echo "Starship prompt is not installed. Installing..."
-        curl -fsSL https://starship.rs/install.sh | bash -s  -- --yes
+        curl -fsSL https://starship.rs/install.sh | sh -s  -- --yes
     fi
 
     local hushfile="$HOME/.hushlogin"

--- a/install
+++ b/install
@@ -167,11 +167,6 @@ setup_shell() {
         sudo sh -c "echo $fish_bin >> $shells_file"
     fi
 
-    if ! default_shell_is "$fish_bin"; then
-        echo "Fish is not currently the default shell. Setting fish to be the default..."
-        chsh -s "$fish_bin"
-    fi
-
     if ! cmd_exists "starship"; then
         echo "Starship prompt is not installed. Installing..."
         curl -fsSL https://starship.rs/install.sh | sh -s  -- --yes
@@ -182,6 +177,9 @@ setup_shell() {
         echo "Creating a hushlogin file"
         touch "$hushfile"
     fi
+
+    echo "Making sure that fish is set to be the default shell"
+    chsh -s "$fish_bin"
 }
 
 # Helper Funcs
@@ -189,13 +187,6 @@ setup_shell() {
 # Returns 0 if the given command ($1) is installed/exists.
 cmd_exists() {
     command -v "$1" &> /dev/null
-}
-
-# Returns 0 if the passed shell ($1) is the user's current default shell.
-default_shell_is() {
-    # dscl is macOS-specific
-    # https://stackoverflow.com/a/41553295
-    [ "$(dscl . -read "$HOME" UserShell | sed 's/UserShell: //')" == "$1" ]
 }
 
 # Returns 0 if a file exists at the given path ($1) and is a regular file.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,6 @@
+This directory stores package lists that are used when running the `install`
+script. Some packages have different names on macOS and Linux, so I use
+separate lists to list out each package for each operating system.
+
+The lists can have blank lines, and lines starting with `#` are viewed as
+comments. Inline comments are not allowed, the first character has to be a `#`.

--- a/packages/linux/apt.txt
+++ b/packages/linux/apt.txt
@@ -1,0 +1,12 @@
+curl
+bat
+exa
+fd-find
+fish
+git
+jq
+less
+python3
+ripgrep
+virtualenv
+wget

--- a/packages/macos/casks.txt
+++ b/packages/macos/casks.txt
@@ -1,0 +1,6 @@
+docker
+iterm2
+font-sf-mono-nerd-font
+raycast
+spotify
+visual-studio-code

--- a/packages/macos/formulae.txt
+++ b/packages/macos/formulae.txt
@@ -1,0 +1,17 @@
+curl
+bat
+exa
+fd
+fish
+gh
+git
+git-delta
+go
+jq
+less
+neovim
+node
+python3
+ripgrep
+virtualenv
+wget

--- a/packages/macos/taps.txt
+++ b/packages/macos/taps.txt
@@ -1,0 +1,4 @@
+homebrew/cask
+homebrew/cask-fonts
+# Needed for font-sf-mono-nerd-font
+epk/epk


### PR DESCRIPTION
This updates the installation to be able to install all packages and dependencies on Ubuntu. The current implementation only supports using `apt` and `dpkg` for installation on Linux as the main target here is just Ubuntu.

There are still quite a few areas where improvements could be made, but it's a start that works for now. One main thing to note is that binaries that are manually installed will be reinstalled on Linux every time the install script is run. This is something I will need to improve. 